### PR TITLE
QuickStart Jupyter notebook: reorder install and download steps to align with quickstart

### DIFF
--- a/lightly_solution.ipynb
+++ b/lightly_solution.ipynb
@@ -4,33 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This jupyter notebook needs to run on a x86_64 CPU. We recommend running it on a Linux machine. It works both with and without a Nvidia GPU."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "latest: Pulling from lightly/worker\n",
-      "Status: Image is up to date for lightly/worker:latest\n",
-      "[2024-03-26 12:27:06] Lightly Worker Solution v2.11.1\u001b[0m\n",
-      "[2024-03-26 12:27:06] Congratulations! It looks like the Lightly container is running!\u001b[0m\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Install the Lightly Worker and do a quick sanity check\n",
-    "# If these commands fail, follow our docker installation guide at https://docs.lightly.ai/docs/install-lightly#docker\n",
-    "!docker pull lightly/worker:latest\n",
-    "!docker run --shm-size=\"1024m\" --rm -it lightly/worker:latest sanity_check=True\n",
-    "\n",
-    "# Install the Lightly Python Client\n",
-    "!pip3 install lightly"
+    "This jupyter notebook must run on a x86 CPU (Intel or AMD), which excludes Apple Mx CPUs. We recommend running it on a Linux machine. It works both with and without a Nvidia GPU."
    ]
   },
   {
@@ -53,6 +27,32 @@
     "# If you want to use your own dataset, just set the dataset_path to it.\n",
     "dataset_path = \"dataset_clothing_images\"\n",
     "!git clone https://github.com/lightly-ai/dataset_clothing_images.git {dataset_path}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "latest: Pulling from lightly/worker\n",
+      "Status: Image is up to date for lightly/worker:latest\n",
+      "[2024-03-26 12:27:06] Lightly Worker Solution v2.11.1\u001b[0m\n",
+      "[2024-03-26 12:27:06] Congratulations! It looks like the Lightly container is running!\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Install the Lightly Python Client\n",
+    "!pip3 install lightly\n",
+    "\n",
+    "# Install the Lightly Worker and do a quick sanity check\n",
+    "# If these commands fail, follow our docker installation guide at https://docs.lightly.ai/docs/install-lightly#docker\n",
+    "!docker pull lightly/worker:latest\n",
+    "!docker run --shm-size=\"1024m\" --rm -it lightly/worker:latest sanity_check=True"
    ]
   },
   {


### PR DESCRIPTION
This PR changes the order in the jupyter notebook to have the same order as the quickstart:
i) download
ii) install pip
iii) install worker

See the order of the download and install steps in the [quickstart](https://docs.lightly.ai/docs/quickstart):

![image](https://github.com/lightly-ai/lightly-solution-all-in-one-notebook/assets/20324507/2d270f08-30f7-40a5-a814-dfcc144ca318)

